### PR TITLE
Add gtfstidy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+FROM golang:1.12-alpine as build
+RUN apk add --no-cache git libc-dev
+RUN go get -v github.com/patrickbr/gtfstidy
+
 FROM node:alpine
 
 WORKDIR /usr/src/app
@@ -8,6 +12,7 @@ COPY package-lock.json .
 
 RUN npm ci
 
+COPY --from=build /go/bin/gtfstidy /bin
 COPY . .
 RUN npm run build:js
 

--- a/server/importers/BaseImporter.ts
+++ b/server/importers/BaseImporter.ts
@@ -56,6 +56,8 @@ abstract class BaseImporter {
 
   abstract download(): void
 
+  abstract optimize(): void
+
   abstract unzip(): void
 
   abstract db(importer: GtfsImport): void
@@ -65,15 +67,15 @@ abstract class BaseImporter {
   files: {
     name: string
     table:
-      | 'agency'
-      | 'stops'
-      | 'routes'
-      | 'trips'
-      | 'stop_times'
-      | 'calendar'
-      | 'calendar_dates'
-      | 'transfers'
-      | 'frequencies'
+    | 'agency'
+    | 'stops'
+    | 'routes'
+    | 'trips'
+    | 'stop_times'
+    | 'calendar'
+    | 'calendar_dates'
+    | 'transfers'
+    | 'frequencies'
     versioned: boolean
   }[]
 

--- a/server/importers/BaseImporter.ts
+++ b/server/importers/BaseImporter.ts
@@ -67,15 +67,15 @@ abstract class BaseImporter {
   files: {
     name: string
     table:
-    | 'agency'
-    | 'stops'
-    | 'routes'
-    | 'trips'
-    | 'stop_times'
-    | 'calendar'
-    | 'calendar_dates'
-    | 'transfers'
-    | 'frequencies'
+      | 'agency'
+      | 'stops'
+      | 'routes'
+      | 'trips'
+      | 'stop_times'
+      | 'calendar'
+      | 'calendar_dates'
+      | 'transfers'
+      | 'frequencies'
     versioned: boolean
   }[]
 

--- a/server/importers/MultiImporter.ts
+++ b/server/importers/MultiImporter.ts
@@ -131,11 +131,14 @@ abstract class MultiImporter extends BaseImporter {
           log.info({ path, name }, 'Renaming feed')
           renameSync(path, `${path}-original.zip`)
           renameSync(`${path}-compressed.zip`, path)
-          log.info({ path, name }, 'Renamed feed - will import optimized version')
+          log.info(
+            { path, name },
+            'Renamed feed - will import optimized version',
+          )
         } catch (error) {
           log.error({ error }, 'Failed to optimize')
         }
-      })
+      }),
     )
   }
 

--- a/server/importers/MultiImporter.ts
+++ b/server/importers/MultiImporter.ts
@@ -1,16 +1,19 @@
-import { existsSync, createWriteStream, mkdirSync } from 'fs'
-import { resolve as _resolve, join } from 'path'
-import rimraf from 'rimraf'
 import axios from 'axios'
+import { exec } from 'child_process'
 import extract from 'extract-zip'
+import { createWriteStream, existsSync, mkdirSync, renameSync } from 'fs'
 import { pRateLimit } from 'p-ratelimit'
-import logger from '../logger'
-import GtfsImport from '../db/gtfs-import'
-import CreateShapes from '../db/create-shapes'
-import Storage from '../db/storage'
-import KeyvalueDynamo from '../db/keyvalue-dynamo'
+import { join, resolve as _resolve } from 'path'
+import rimraf from 'rimraf'
+import { promisify } from 'util'
 import config from '../config'
+import CreateShapes from '../db/create-shapes'
+import GtfsImport from '../db/gtfs-import'
+import KeyvalueDynamo from '../db/keyvalue-dynamo'
+import Storage from '../db/storage'
+import logger from '../logger'
 import BaseImporter from './BaseImporter'
+const execAsync = promisify(exec)
 
 const log = logger(config.prefix, config.version)
 
@@ -114,6 +117,26 @@ abstract class MultiImporter extends BaseImporter {
       const location = locations[index]
       await this.rateLimiter(() => this.get(location))
     }
+  }
+
+  optimize = async () => {
+    log.info('Optimizing GTFS Data')
+    await Promise.all(
+      this.zipLocations.map(async ({ path, name }) => {
+        try {
+          const { stdout, stderr } = await execAsync(
+            `gtfstidy --compress ${path} -o ${path}-compressed.zip`,
+          )
+          log.info({ path, name, stdout, stderr }, 'Optimized feed')
+          log.info({ path, name }, 'Renaming feed')
+          renameSync(path, `${path}-original.zip`)
+          renameSync(`${path}-compressed.zip`, path)
+          log.info({ path, name }, 'Renamed feed - will import optimized version')
+        } catch (error) {
+          log.error({ error }, 'Failed to optimize')
+        }
+      })
+    )
   }
 
   unzip = async () => {

--- a/server/importers/SingleImporter.ts
+++ b/server/importers/SingleImporter.ts
@@ -1,16 +1,15 @@
-import { resolve as _resolve, join } from 'path'
-import { createWriteStream, existsSync, mkdirSync, renameSync } from 'fs'
-import { promisify } from 'util'
-import { exec } from 'child_process'
-import rimraf from 'rimraf'
-import extract from 'extract-zip'
 import axios from 'axios'
-import BaseImporter from './BaseImporter'
-
+import { exec } from 'child_process'
+import extract from 'extract-zip'
+import { createWriteStream, existsSync, mkdirSync, renameSync } from 'fs'
+import { join, resolve as _resolve } from 'path'
+import rimraf from 'rimraf'
+import { promisify } from 'util'
 import config from '../config'
-import logger from '../logger'
 import CreateShapes from '../db/create-shapes'
 import GtfsImport from '../db/gtfs-import'
+import logger from '../logger'
+import BaseImporter from './BaseImporter'
 
 const execAsync = promisify(exec)
 

--- a/server/importers/index.ts
+++ b/server/importers/index.ts
@@ -124,6 +124,7 @@ class Importer {
     // if the db is already there, avoid the first few steps
     if (!created) {
       await this.download()
+      await this.optimize()
       await this.unzip()
       await this.db()
     } else {
@@ -156,12 +157,16 @@ class Importer {
     }
   }
 
-  unzip = async () => {
-    if (this.current) await this.current.unzip()
-  }
-
   download = async () => {
     if (this.current) await this.current.download()
+  }
+
+  optimize = async () => {
+    if (this.current) await this.current.optimize()
+  }
+
+  unzip = async () => {
+    if (this.current) await this.current.unzip()
   }
 
   db = async () => {


### PR DESCRIPTION
gtfstidy does a bunch of things to reduce the file size of the GTFS feed, while keeping the external references (trip ids etc) the same. Mostly, it optimizes shapes, and trims the calendar & calendar dates tables. This should reduce our DB size, and make our queries run faster.

It's a simple golang command line app (compiled with a build container and copied over), that takes the original zip file, and outputs the optimized version. If gtfstidy isn't installed, it should just skip over the optimize step.

e.g with auckland:
```
13M  4 Jan 10:25 at.zip
29M  4 Jan 00:38 at.zip-original.zip
```

e.g with canberra:
```
2.9M Jan  3 21:15 cbrbuses.zip
4.8M Jan  3 21:15 cbrbuses.zip-original.zip
65.2K Jan  3 21:15 cbrlightrail.zip
84.3K Jan  3 21:15 cbrlightrail.zip-original.zip
```